### PR TITLE
use pyfftw if available

### DIFF
--- a/src/imreg_dft/imreg.py
+++ b/src/imreg_dft/imreg.py
@@ -40,7 +40,10 @@ from __future__ import division, print_function
 import math
 
 import numpy as np
-import numpy.fft as fft
+try:
+    import pyfftw.interfaces.numpy_fft as fft
+except ImportError:
+    import numpy.fft as fft
 import scipy.ndimage.interpolation as ndii
 
 import imreg_dft.utils as utils


### PR DESCRIPTION
Hi!
Nice package! :+1: 

The C library FFTW is quite speedy compared to numpys fft, so checking if its available would be nice.

Here is a speed comparison:
![skjermbilde 2015-04-29 kl 08 50 05](https://cloud.githubusercontent.com/assets/4810521/7385875/42df9008-ee4d-11e4-9e10-f93f75fa79cd.png)
