### PR TITLE
pip install will fail if dependencies are not already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,22 @@ SETUPDIR = os.path.dirname(__file__)
 PKGDIR = os.path.join(SETUPDIR, 'src')
 
 sys.path.append(PKGDIR)
-import imreg_dft
 
 reqsfname = os.path.join(SETUPDIR, 'requirements.txt')
 reqs = open(reqsfname, 'r').read().strip().splitlines()
+
+# get version from __init__.py without importing
+versfname = os.path.join(PKGDIR, 'imreg_dft', '__init__.py')
+init_lines = open(versfname).readlines()
+version_line = next(filter(lambda x: '__version__' in x, init_lines))
+version = version_line.split('"')[1]
 
 descfname = os.path.join(SETUPDIR, 'doc', 'description.rst')
 longdesc = open(descfname, 'r').read()
 
 st.setup(
     name="imreg_dft",
-    version=imreg_dft.__version__,
+    version=version,
     author=u"Matěj Týč",
     author_email="matej.tyc@gmail.com",
     description=("Image registration utility using algorithms based on "

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ reqs = open(reqsfname, 'r').read().strip().splitlines()
 # get version from __init__.py without importing
 versfname = os.path.join(PKGDIR, 'imreg_dft', '__init__.py')
 init_lines = open(versfname).readlines()
-version_line = next(filter(lambda x: '__version__' in x, init_lines))
+version_line = list(filter(lambda x: '__version__' in x, init_lines))[0]
 version = version_line.split('"')[1]
 
 descfname = os.path.join(SETUPDIR, 'doc', 'description.rst')


### PR DESCRIPTION
Traceback:
```sh
  Using cached imreg_dft-1.0.4.tar.gz
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/var/folders/mx/t9hzs5852cxgk0548k1vdsxr0000gn/T/pip-build-looz8ycr/imreg-dft/setup.py", line 8, in <module>
        import imreg_dft
      File "src/imreg_dft/__init__.py", line 1, in <module>
        from imreg_dft.imreg import *
      File "src/imreg_dft/imreg.py", line 42, in <module>
        import numpy as np
    ImportError: No module named 'numpy'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
    
      File "<string>", line 20, in <module>
    
      File "/var/folders/mx/t9hzs5852cxgk0548k1vdsxr0000gn/T/pip-build-looz8ycr/imreg-dft/setup.py", line 8, in <module>
    
        import imreg_dft
    
      File "src/imreg_dft/__init__.py", line 1, in <module>
    
        from imreg_dft.imreg import *
    
      File "src/imreg_dft/imreg.py", line 42, in <module>
    
        import numpy as np
    
    ImportError: No module named 'numpy'
    
    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /var/folders/mx/t9hzs5852cxgk0548k1vdsxr0000gn/T/pip-build-looz8ycr/imreg-dft
```

This PR reads `__init__.py` instead of importing imreg and causing the error.