### PR TITLE
read files as utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import setuptools as st
+from io import open
 
 # Fix so that the setup.py usage is CWD-independent
 SETUPDIR = os.path.abspath(os.path.dirname(__file__))
@@ -13,10 +14,10 @@ sys.path.append(PKGDIR)
 import imreg_dft
 
 reqsfname = os.path.join(SETUPDIR, 'requirements.txt')
-reqs = open(reqsfname, 'r').read().strip().splitlines()
+reqs = open(reqsfname, 'r', encoding='utf-8').read().strip().splitlines()
 
 descfname = os.path.join(SETUPDIR, 'doc', 'description.rst')
-longdesc = open(descfname, 'r').read()
+longdesc = open(descfname, 'r', encoding='utf-8').read()
 
 st.setup(
     name="imreg_dft",


### PR DESCRIPTION
...or get error on non utf8 systems:

```
C:\Users\TCS-User\Downloads>pip install imreg_dft
Collecting imreg-dft
  Using cached imreg_dft-1.0.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "C:\Users\TCS-User\AppData\Local\Temp\pip-build-h4hs64lt\imreg-dft\se
tup.py", line 12, in <module>
        longdesc = open(os.path.join('doc', 'description.rst'), 'r').read()
      File "C:\Users\TCS-User\Miniconda32\lib\encodings\cp1252.py", line 23, in
decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 739:
character maps to <undefined>

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in C:\Users\TCS-
User\AppData\Local\Temp\pip-build-h4hs64lt\imreg-dft
```